### PR TITLE
Add ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,13 @@
 container:
   image: cirrusci/flutter:latest
 
+analysis_task:
+  pub_cache:
+    folder: ~/.pub-cache
+  analysis_script: |
+    flutter pub get
+    flutter analyze
+
 test_task:
   pub_cache:
     folder: ~/.pub-cache

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,14 @@
+container:
+  image: cirrusci/flutter:latest
+
+test_task:
+  pub_cache:
+    folder: ~/.pub-cache
+  # test_script: flutter test --machine > report.json
+  test_script: |
+    flutter pub get
+    flutter test --reporter json > report.json
+  always:
+    report_artifacts:
+      path: report.json
+      format: flutter


### PR DESCRIPTION
flutterはバージョンが頻繁に上がるし、
自分も大きな変更をしたときに何処かが壊れることに気づけると助かるので、
やっぱりCIは入れておきたい。

いくつかサービスがありそうですが、
flutter公式が採用しているCirrus CIがとりあえず安心そう。

テスト以外にも、静的解析を追加しています。
これも初心者の自分がイマイチな書き方で放置しないようにするのにとても有用だと思っています。