### PR TITLE
記事を保存

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ test_task:
   # test_script: flutter test --machine > report.json
   test_script: |
     flutter pub get
-    flutter test --reporter json | tee report.json
+    flutter test --concurrency=1 --reporter json | tee report.json
   always:
     report_artifacts:
       path: report.json

--- a/lib/widgets/article_page.dart
+++ b/lib/widgets/article_page.dart
@@ -1,3 +1,4 @@
+import 'package:f_diary/isar_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:f_diary/models/article.dart';
 
@@ -28,11 +29,25 @@ class _ArticleState extends State<ArticlePage> {
                   initialValue: article.title,
                   decoration: const InputDecoration(
                       labelText: 'タイトル', hintText: '今日をひとことでいうとなんですか？'),
+                  onChanged: (value) {
+                    article.title = value;
+                    article.updatedAt = DateTime.now();
+                    isar.writeTxnSync((isar) {
+                      article.id = isar.articles.putSync(article);
+                    });
+                  },
                 ),
                 TextFormField(
                   initialValue: article.body,
                   decoration: const InputDecoration(labelText: '内容'),
                   maxLines: 10,
+                  onChanged: (value) {
+                    article.body = value;
+                    article.updatedAt = DateTime.now();
+                    isar.writeTxnSync((isar) {
+                      article.id = isar.articles.putSync(article);
+                    });
+                  },
                 )
               ],
             )));

--- a/lib/widgets/article_page.dart
+++ b/lib/widgets/article_page.dart
@@ -27,6 +27,7 @@ class _ArticleState extends State<ArticlePage> {
               children: [
                 TextFormField(
                   initialValue: article.title,
+                  key: const ValueKey('articleTitleTextField'),
                   decoration: const InputDecoration(
                       labelText: 'タイトル', hintText: '今日をひとことでいうとなんですか？'),
                   onChanged: (value) {
@@ -39,6 +40,7 @@ class _ArticleState extends State<ArticlePage> {
                 ),
                 TextFormField(
                   initialValue: article.body,
+                  key: const ValueKey('articleBodyTextField'),
                   decoration: const InputDecoration(labelText: '内容'),
                   maxLines: 10,
                   onChanged: (value) {

--- a/lib/widgets/article_page.dart
+++ b/lib/widgets/article_page.dart
@@ -32,10 +32,7 @@ class _ArticleState extends State<ArticlePage> {
                       labelText: 'タイトル', hintText: '今日をひとことでいうとなんですか？'),
                   onChanged: (value) {
                     article.title = value;
-                    article.updatedAt = DateTime.now();
-                    isar.writeTxnSync((isar) {
-                      article.id = isar.articles.putSync(article);
-                    });
+                    _saveArticle(article);
                   },
                 ),
                 TextFormField(
@@ -45,13 +42,17 @@ class _ArticleState extends State<ArticlePage> {
                   maxLines: 10,
                   onChanged: (value) {
                     article.body = value;
-                    article.updatedAt = DateTime.now();
-                    isar.writeTxnSync((isar) {
-                      article.id = isar.articles.putSync(article);
-                    });
+                    _saveArticle(article);
                   },
                 )
               ],
             )));
+  }
+
+  void _saveArticle(Article article) {
+    article.updatedAt = DateTime.now();
+    isar.writeTxnSync((isar) {
+      article.id = isar.articles.putSync(article);
+    });
   }
 }

--- a/test/widgets/article_page_test.dart
+++ b/test/widgets/article_page_test.dart
@@ -41,4 +41,32 @@ void main() {
       });
     });
   });
+
+  group('既存の記事を指定されたとき', () {
+    var article = Article()
+      ..title = '記事のタイトル'
+      ..body = '記事の本文'
+      ..createdAt = DateTime.now()
+      ..updatedAt = DateTime.now();
+
+    var articlePage = ArticlePage(article);
+
+    testWidgets('ページが表示されること', (WidgetTester tester) async {
+      await tester.pumpWidget(TestHelper.wrapWithMaterial(articlePage));
+
+      expect(find.text('記事のタイトル'), findsOneWidget);
+      expect(find.text('記事の本文'), findsOneWidget);
+    });
+
+    testWidgets('変更後に自動的に保存されていること', (WidgetTester tester) async {
+      await tester.pumpWidget(TestHelper.wrapWithMaterial(articlePage));
+      await tester.enterText(
+          find.byKey(const ValueKey('articleTitleTextField')), '変更後の記事のタイトル');
+      await tester.enterText(
+          find.byKey(const ValueKey('articleBodyTextField')), '変更後の記事の本文');
+      var savedArticle = isar.articles.where().findFirstSync();
+      expect(savedArticle?.title, equals('変更後の記事のタイトル'));
+      expect(savedArticle?.body, equals('変更後の記事の本文'));
+    });
+  });
 }

--- a/test/widgets/article_page_test.dart
+++ b/test/widgets/article_page_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:f_diary/isar_helper.dart';
+import 'package:f_diary/models/article.dart';
+
+import 'package:isar/isar.dart';
+import 'package:f_diary/widgets/article_page.dart';
+import '../test_helper.dart';
+
+void main() {
+  TestHelper.wrapTest(() async {
+    group('未保存の記事を指定されたとき', () {
+      var article = Article()
+        ..title = ''
+        ..body = ''
+        ..createdAt = DateTime.now()
+        ..updatedAt = DateTime.now();
+
+      var articlePage = ArticlePage(article);
+
+      testWidgets('ページが表示されること', (WidgetTester tester) async {
+        await tester.pumpWidget(TestHelper.wrapWithMaterial(articlePage));
+
+        var dateTime = DateTime.now();
+        var titleString = '${dateTime.year}-${dateTime.month}-${dateTime.day}';
+
+        expect(find.text(titleString, skipOffstage: false), findsOneWidget);
+        var savedArticle = isar.articles.where().findFirstSync();
+        expect(savedArticle, equals(null));
+      });
+
+      testWidgets('記入後に自動的に保存されていること', (WidgetTester tester) async {
+        await tester.pumpWidget(TestHelper.wrapWithMaterial(articlePage));
+        await tester.enterText(
+            find.byKey(const ValueKey('articleTitleTextField')), '記事のタイトル');
+        await tester.enterText(
+            find.byKey(const ValueKey('articleBodyTextField')), '記事の本文');
+        var savedArticle = isar.articles.where().findFirstSync();
+        expect(savedArticle?.title, equals('記事のタイトル'));
+        expect(savedArticle?.body, equals('記事の本文'));
+      });
+    });
+  });
+}


### PR DESCRIPTION
記事を保存できるようにします。

一覧から `+` マークをタップすると新規作成、一覧のタイトルがついているところをタップすると編集になります。

## その他
- テストの並列実行をやめました。
  - isarのオープンを並列で行うことができず、テストが失敗していました。きっとそれがうまく行っていてもテストデータが同時に入ってしまったりして想定外になりそうです。