### PR TITLE
IsarSupport.dartをCommon.dartに改名

### DIFF
--- a/lib/common.dart
+++ b/lib/common.dart
@@ -1,16 +1,19 @@
+import 'dart:io';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:f_diary/models/article.dart';
 
+late Directory applicationDocumentsDirectory;
 late Isar isar;
 
 class Common {
   static var schemas = [ArticleSchema];
 
   static Future<void> initialize() async {
+    applicationDocumentsDirectory = await getApplicationDocumentsDirectory();
     isar = await Isar.open(
       schemas: schemas,
-      directory: (await getApplicationDocumentsDirectory()).path,
+      directory: applicationDocumentsDirectory.path,
     );
   }
 

--- a/lib/common.dart
+++ b/lib/common.dart
@@ -4,7 +4,7 @@ import 'package:f_diary/models/article.dart';
 
 late Isar isar;
 
-class IsarHelper {
+class Common {
   static var schemas = [ArticleSchema];
 
   static Future<void> initialize() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 
 import 'package:intl/date_symbol_data_local.dart';
 
-import 'package:f_diary/isar_helper.dart';
+import 'package:f_diary/common.dart';
 import 'package:f_diary/widgets/my_home_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initializeDateFormatting('ja_JP');
-  await IsarHelper.initialize();
+  await Common.initialize();
   // IsarHelper.addSampleArticle(); // あとで削除
 
   runApp(const MyApp());

--- a/lib/widgets/article_page.dart
+++ b/lib/widgets/article_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:intl/intl.dart';
 
-import 'package:f_diary/isar_helper.dart';
+import 'package:f_diary/common.dart';
 import 'package:f_diary/models/article.dart';
 
 class ArticlePage extends StatefulWidget {

--- a/lib/widgets/my_home_page.dart
+++ b/lib/widgets/my_home_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:isar/isar.dart';
-import 'package:f_diary/isar_helper.dart';
+import 'package:f_diary/common.dart';
 import 'package:f_diary/models/article.dart';
 import 'package:f_diary/widgets/article_page.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -333,6 +333,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -526,7 +533,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   time:
     dependency: transitive
     description:

--- a/test/supports/common_support.dart
+++ b/test/supports/common_support.dart
@@ -1,0 +1,8 @@
+import 'dart:io';
+import 'package:f_diary/common.dart';
+
+class CommonSupport {
+  static void initialize() {
+    applicationDocumentsDirectory = Directory("${Directory.current.path}/tmp");
+  }
+}

--- a/test/supports/isar_support.dart
+++ b/test/supports/isar_support.dart
@@ -1,11 +1,9 @@
 import 'package:isar/isar.dart';
-import 'dart:io';
 import 'package:f_diary/common.dart';
 
 class IsarSupport {
   static void initilize() {
-    var directory = "${Directory.current.path}/tmp";
-    isar = Isar.openSync(schemas: Common.schemas, directory: directory);
+    isar = Isar.openSync(schemas: Common.schemas, directory: applicationDocumentsDirectory.path);
   }
 
   static void finalize() {

--- a/test/supports/isar_support.dart
+++ b/test/supports/isar_support.dart
@@ -1,11 +1,11 @@
 import 'package:isar/isar.dart';
 import 'dart:io';
-import 'package:f_diary/isar_helper.dart';
+import 'package:f_diary/common.dart';
 
 class IsarSupport {
   static void initilize() {
     var directory = "${Directory.current.path}/tmp";
-    isar = Isar.openSync(schemas: IsarHelper.schemas, directory: directory);
+    isar = Isar.openSync(schemas: Common.schemas, directory: directory);
   }
 
   static void finalize() {

--- a/test/test_helper.dart
+++ b/test/test_helper.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'supports/common_support.dart';
 import 'supports/isar_support.dart';
 import 'supports/intl_support.dart';
 
 class TestHelper {
   static void wrapTest(void Function() body) {
     setUpAll(() async {
+      CommonSupport.initialize();
       IsarSupport.initilize();
       await IntlSupport.initilize();
     });

--- a/test/widgets/article_page_test.dart
+++ b/test/widgets/article_page_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
-import 'package:f_diary/isar_helper.dart';
+import 'package:f_diary/common.dart';
 import 'package:f_diary/models/article.dart';
 
 import 'package:isar/isar.dart';

--- a/test/widgets/my_home_page_test.dart
+++ b/test/widgets/my_home_page_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:f_diary/isar_helper.dart';
+import 'package:f_diary/common.dart';
 import 'package:f_diary/models/article.dart';
 
 import 'package:f_diary/widgets/my_home_page.dart';


### PR DESCRIPTION
初期化処理を〜Supportクラスにそれぞれまとめようと思ったのですが、あんまり数もないので、一旦一緒にしてしまいます。