### PR TITLE
FileConverterの修正

### DIFF
--- a/lib/file_converter.dart
+++ b/lib/file_converter.dart
@@ -11,8 +11,13 @@ class FileConverter extends TypeConverter<File?, String?> {
   File? fromIsar(String? filePath) {
     if (filePath == null || filePath == '') {
       return null;
+    }
+
+    var file = File(filePath);
+    if (file.existsSync()) {
+      return file;
     } else {
-      return File(filePath);
+      return null;
     }
   }
 
@@ -21,6 +26,10 @@ class FileConverter extends TypeConverter<File?, String?> {
   String? toIsar(File? file) {
     if (file == null) {
       return '';
+    }
+
+    if (file.parent.path == baseDir.path) {
+      return file.path;
     }
 
     var digest = crypto.md5.convert(file.readAsBytesSync());

--- a/test/file_converter_test.dart
+++ b/test/file_converter_test.dart
@@ -29,9 +29,19 @@ void main() {
           expect(fileConverter.fromIsar(filePath), equals(null));
         });
       });
-      group('filePath = foo/bar.png のとき', () {
+      group('filePath = not_exist/bar.png(存在しないファイル) のとき', () {
         setUp(() {
-          filePath = 'foo/bar.png';
+          filePath = 'not_exist/bar.png';
+        });
+
+        test('nullを返すこと', () {
+          expect(fileConverter.fromIsar(filePath), equals(null));
+        });
+      });
+
+      group('filePath = test/fixtures/images/480x320.png(存在するファイル) のとき', () {
+        setUp(() {
+          filePath = File('test/fixtures/images/480x320.png').path;
         });
 
         test('Fileを返すこと', () {
@@ -59,6 +69,22 @@ void main() {
       group('file = test/fixtures/images/480x320.pngのとき', () {
         setUp(() {
           file = File('test/fixtures/images/480x320.png');
+        });
+        test('アプリケーションディレクトリに保存されたパスを返すこと', () {
+          var filePath = fileConverter.toIsar(file);
+          // 1acc05735f503e8471e440efcad1706d は480x320.pngのMD5値
+          expect(
+              filePath, endsWith('files/1acc05735f503e8471e440efcad1706d.png'));
+          expect(File(filePath!).existsSync(), isTrue);
+        });
+      });
+
+      group(
+          'file = test/fixtures/images/480x320.png(アプリケーションの保存ディレクトリにすでにあるファイル)のとき',
+          () {
+        setUp(() {
+          var orgFile = File('test/fixtures/images/480x320.png');
+          file = File(fileConverter.toIsar(orgFile)!);
         });
         test('アプリケーションディレクトリに保存されたパスを返すこと', () {
           var filePath = fileConverter.toIsar(file);


### PR DESCRIPTION
- 保存ディレクトリにあるときに既存ファイルを削除していたので修正
- 記録されているパスのファイルが存在しないときはnullを返すように変更