### PR TITLE
記事編集ページのタイトルを修正

### DIFF
--- a/lib/widgets/article_page.dart
+++ b/lib/widgets/article_page.dart
@@ -23,12 +23,10 @@ class _ArticleState extends State<ArticlePage> {
   @override
   Widget build(BuildContext context) {
     var article = widget.article;
-    var dateTime = article.createdAt;
-    var titleString = '${dateTime.year}-${dateTime.month}-${dateTime.day}';
     imageFile = article.imageFile;
 
     return Scaffold(
-        appBar: AppBar(title: Text(titleString)),
+        appBar: AppBar(title: const Text('記事の編集')),
         body: Padding(
             padding: const EdgeInsets.all(16),
             child: ListView(

--- a/test/widgets/article_page_test.dart
+++ b/test/widgets/article_page_test.dart
@@ -23,10 +23,7 @@ void main() {
       testWidgets('ページが表示されること', (WidgetTester tester) async {
         await tester.pumpWidget(TestHelper.wrapWithMaterial(articlePage));
 
-        var dateTime = DateTime.now();
-        var titleString = '${dateTime.year}-${dateTime.month}-${dateTime.day}';
-
-        expect(find.text(titleString, skipOffstage: false), findsOneWidget);
+        expect(find.text('記事の編集', skipOffstage: false), findsOneWidget);
         var savedArticle = isar.articles.where().findFirstSync();
         expect(savedArticle, equals(null));
       });

--- a/test/widgets/my_home_page_test.dart
+++ b/test/widgets/my_home_page_test.dart
@@ -66,9 +66,7 @@ void main() {
       await tester.tap(find.byIcon(Icons.edit));
       await tester.pump();
 
-      var dateTime = DateTime.now();
-      var titleString = '${dateTime.year}-${dateTime.month}-${dateTime.day}';
-      expect(find.text(titleString, skipOffstage: false), findsOneWidget);
+      expect(find.text('記事の編集', skipOffstage: false), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
編集ページのタイトルに作成日を入れていましたが、これは投稿日を導入する前に、どの日の記事なのか示すためのものでした。
現在は不要なので、修正します。

![image](https://user-images.githubusercontent.com/2942348/158044366-a2ed5eb4-7ddd-4d06-8d00-aa73c6d7fc39.png)
