### PR TITLE
テストを並列実行に戻す

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ test_task:
   # test_script: flutter test --machine > report.json
   test_script: |
     flutter pub get
-    flutter test --concurrency=1 --reporter json | tee report.json
+    flutter test --reporter json | tee report.json
   always:
     report_artifacts:
       path: report.json

--- a/README.md
+++ b/README.md
@@ -17,13 +17,6 @@ github="https://github.com/isar/isar-core/releases/download/${core_version}"
 curl "${github}/libisar_macos_x64.dylib" -o ./libisar.dylib --create-dirs -L
 ```
 
-### テスト
-テストを並列実行できるようにIsarを設定できていないので、必ず直列に実行します。
-
-```console
-flutter test --concurrency=1
-```
-
 ### Dartパッケージのバージョンアップ
 Isarのみ、バージョンを固定しています。
 通常の手順で更新できます。

--- a/test/supports/common_support.dart
+++ b/test/supports/common_support.dart
@@ -3,6 +3,12 @@ import 'package:f_diary/common.dart';
 
 class CommonSupport {
   static void initialize() {
-    applicationDocumentsDirectory = Directory("${Directory.current.path}/tmp");
+    applicationDocumentsDirectory =
+        Directory("${Directory.current.path}/tmp/$pid");
+    applicationDocumentsDirectory.createSync(recursive: true);
+  }
+
+  static void finalize() {
+    applicationDocumentsDirectory.deleteSync(recursive: true);
   }
 }

--- a/test/test_helper.dart
+++ b/test/test_helper.dart
@@ -17,6 +17,10 @@ class TestHelper {
     tearDown(() {
       IsarSupport.finalize();
     });
+
+    tearDownAll(() {
+      CommonSupport.finalize();
+    });
   }
 
   static Widget wrapWithMaterial(Widget widget) {


### PR DESCRIPTION
作業ディレクトリをプロセスIDごとに分け、
それによってIsarデータベースが複数使えるようになったので、
テストを直列実行から並列実行に戻します。